### PR TITLE
Update of spamhaus.org address

### DIFF
--- a/config/postfix/main.cf
+++ b/config/postfix/main.cf
@@ -100,7 +100,7 @@ smtpd_client_restrictions =
     permit_sasl_authenticated, 
     reject_rbl_client bl.spamcop.net, 
     reject_rbl_client cbl.abuseat.org, 
-    reject_rbl_client sbl-xbl.spamhaus.org, 
+    reject_rbl_client zen.spamhaus.org, 
     permit 
  
 # Requirements for the HELO statement 


### PR DESCRIPTION
Also, I'm not sure if we should keep cbl.abuseat.org

http://www.dnsbl.info/dnsbl-details.php?dnsbl=zen.spamhaus.org

ZEN is the combination of all Spamhaus DNSBLs into one single powerful and comprehensive blocklist to make querying faster and simpler. It contains the SBL, the XBL and the PBL blocklist. 

In most cases, zen.spamhaus.org replaces sbl-xbl.spamhaus.org. If you are currently using sbl-xbl.spamhaus.org you should now replace 'sbl-xbl.spamhaus.org' with 'zen.spamhaus.org'. 

zen.spamhaus.org should now be the only spamhaus.org DNSBL in your configuration. You should not use ZEN together with other Spamhaus blocklists, or with blocklists already included in our zones (such as the CBL) or you will simply be wasting DNS queries and slowing your mail queue. 

Caution: Because ZEN includes the XBL and PBL lists, do not use ZEN on smarthosts or SMTP AUTH outbound servers for your own customers (or you risk blocking your own customers). Do not use ZEN in filters that do any ‘deep parsing’ of Received headers, or for other than checking IP addresses that hand off to your mailservers.	

Technical Details
Website: www.spamhaus.org/zen/
Lookup: zen.spamhaus.org