### PR TITLE
More security in postfix

### DIFF
--- a/config/postfix/main.cf
+++ b/config/postfix/main.cf
@@ -31,10 +31,11 @@ smtpd_tls_auth_only=yes
 smtpd_tls_cert_file=/etc/ssl/certs/yunohost_crt.pem
 smtpd_tls_key_file=/etc/ssl/private/yunohost_key.pem
 smtpd_tls_CAfile = /etc/ssl/certs/ca-yunohost_crt.pem
-smtpd_tls_exclude_ciphers = aNULL, MD5, DES, ADH
+smtpd_tls_exclude_ciphers = aNULL, MD5, DES, ADH, RC4
 smtpd_tls_session_cache_database = btree:${data_directory}/smtpd_scache
 smtpd_tls_loglevel=1
 smtpd_tls_mandatory_protocols=!SSLv2,!SSLv3
+smtpd_tls_mandatory_ciphers=high
 
 # -- TLS for outgoing connections
 # Use TLS if this is supported by the remote SMTP server, otherwise use plaintext.


### PR DESCRIPTION
Add RC4 in the list of excludes ciphers
Add smtpd_tls_mandatory_ciphers=high to use only "high" level ciphers